### PR TITLE
get pcu from engpar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,6 @@ message(STATUS "Kokkos enabled - Overriding compiler flags for consistency with 
 string(REPLACE ";" " " CMAKE_CXX_FLAGS "${KOKKOS_CXX_FLAGS}")
 message(STATUS "Kokkos CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
 
-find_package(SCOREC REQUIRED COMPONENTS pcu)
-
 find_package(EnGPar REQUIRED)
 set(ENGPAR_ENABLED true)
 include_directories(${ENGPAR_INCLUDE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(pumipic-core
   particleStructs
   Omega_h::omega_h
   EnGPar::engpar
-  SCOREC::pcu
+  EnGPar::pcu
   )
 pumipic_export_lib(pumipic-core "${HEADERS}")
 


### PR DESCRIPTION
This works with an engpar build that does not include PUMI.  I'm not sure what happens when engpar is getting pcu from pumi. Maybe we just don't support that?