### PR TITLE
Enable barycentric coordinate calculation to be based on vertex notation

### DIFF
--- a/src/pumipic_adjacency.hpp
+++ b/src/pumipic_adjacency.hpp
@@ -45,8 +45,8 @@ namespace pumipic
 //compute the area coordinates formed by each edge of searchElm
 //the coordinates are returned in the order of the edges bounding
 //searchElm
-// vshift is to specify whether the returned Bcc will be in edge based notation
-// or vertex based notation; default is edge based notation
+// vertex_major is to specify whether the returned Bcc will be in edge based
+// notation or vertex based notation; default is edge based notation
 OMEGA_H_DEVICE void barycentric_tri(
   const o::Reals triArea,
   const o::Matrix<TriDim, TriVerts> &faceCoords,

--- a/src/pumipic_adjacency.hpp
+++ b/src/pumipic_adjacency.hpp
@@ -56,8 +56,8 @@ OMEGA_H_DEVICE void barycentric_tri(
   const auto parent_area = triArea[searchElm];
   const auto vshift = vertex_major ? 1 : 0;
   for(int i=0; i<3; i++) {
-    const auto kIdx = simplex_down_template(o::FACE, o::EDGE, i+vshift, 0);
-    const auto lIdx = simplex_down_template(o::FACE, o::EDGE, i+vshift, 1);
+    const auto kIdx = simplex_down_template(o::FACE, o::EDGE, (i+vshift)%3, 0);
+    const auto lIdx = simplex_down_template(o::FACE, o::EDGE, (i+vshift)%3, 1);
     const auto kxy = faceCoords[kIdx];
     const auto lxy = faceCoords[lIdx];
     o::Few<o::Vector<2>, 2> tri;

--- a/src/pumipic_adjacency.hpp
+++ b/src/pumipic_adjacency.hpp
@@ -32,6 +32,12 @@ namespace pumipic
           \   |   /
             \ | /
               1
+   triangle:
+              1
+             / \
+            1   0
+           /     \
+          2---2---0
 */
 
 #define TriVerts 3
@@ -40,11 +46,11 @@ namespace pumipic
 //the coordinates are returned in the order of the edges bounding
 //searchElm
 OMEGA_H_DEVICE void barycentric_tri(
-    const o::Reals triArea,
-    const o::Matrix<TriDim, TriVerts> &faceCoords,
-    const o::Vector<TriDim> &pos,
-    o::Vector<TriVerts> &bcc,
-    const int searchElm) {
+  const o::Reals triArea,
+  const o::Matrix<TriDim, TriVerts> &faceCoords,
+  const o::Vector<TriDim> &pos,
+  o::Vector<TriVerts> &bcc,
+  const int searchElm) {
   const auto parent_area = triArea[searchElm];
   for(int i=0; i<3; i++) {
     const auto kIdx = simplex_down_template(o::FACE, o::EDGE, i, 0);

--- a/src/pumipic_adjacency.hpp
+++ b/src/pumipic_adjacency.hpp
@@ -45,16 +45,19 @@ namespace pumipic
 //compute the area coordinates formed by each edge of searchElm
 //the coordinates are returned in the order of the edges bounding
 //searchElm
+// vshift is to specify whether the returned Bcc will be in edge based notation
+// or vertex based notation; default is edge based notation
 OMEGA_H_DEVICE void barycentric_tri(
   const o::Reals triArea,
   const o::Matrix<TriDim, TriVerts> &faceCoords,
   const o::Vector<TriDim> &pos,
   o::Vector<TriVerts> &bcc,
-  const int searchElm) {
+  const int searchElm, const bool vertex_major=false) {
   const auto parent_area = triArea[searchElm];
+  const auto vshift = vertex_major ? 1 : 0;
   for(int i=0; i<3; i++) {
-    const auto kIdx = simplex_down_template(o::FACE, o::EDGE, i, 0);
-    const auto lIdx = simplex_down_template(o::FACE, o::EDGE, i, 1);
+    const auto kIdx = simplex_down_template(o::FACE, o::EDGE, i+vshift, 0);
+    const auto lIdx = simplex_down_template(o::FACE, o::EDGE, i+vshift, 1);
     const auto kxy = faceCoords[kIdx];
     const auto lxy = faceCoords[lIdx];
     o::Few<o::Vector<2>, 2> tri;


### PR DESCRIPTION
Enable barycentric coordinate calculation to be based on vertex notation. Currently, the calculated (returned) barycentric coordinate is based on edge index, even though the inputs are ordered according to the 3 vertices of the triangle. 
https://github.com/SCOREC/pumi-pic/blob/d4b0a400092fdf26f9f44613824b0203d9874779/src/pumipic_adjacency.hpp#L37-L60

This is fine for mesh operations (adjacency search, etc.), however, will be problematic for particle-to-mesh based operation such as charge scatter.