### PR TITLE
Add find MPI in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ if(IS_TESTING)
   endif()
 endif()
 
+# find MPI
+find_package(MPI REQUIRED)
 #get the mpirun binary/script
 get_filename_component(COMPILER_DIR "${CMAKE_CXX_COMPILER}" PATH)
 find_program(MPIRUN NAMES mpirun PATHS "${COMPILER_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ if(IS_TESTING)
 endif()
 
 # find MPI
-find_package(MPI REQUIRED)
+set(pumipic_USE_MPI_DEFAULT ON)
+bob_public_dep(MPI 3)
 #get the mpirun binary/script
 get_filename_component(COMPILER_DIR "${CMAKE_CXX_COMPILER}" PATH)
 find_program(MPIRUN NAMES mpirun PATHS "${COMPILER_DIR}")


### PR DESCRIPTION
Explicitly finding `MPI` package. With `kokkos 3.1.0`, `cuda 10.2` and `gcc 7.3.1`, the code was building fine, without adding this in `CMakeLists.txt` file. This, however, resulted in the following errors with `kokkos 3.4.01`, cuda 11.3.1`, and `gcc 7.3.1`:

Error during `cmake configure`:
```
-- Kokkos_VERSION: 3.4.01
-- CMAKE_CXX_FLAGS   
-- PS_IS_TESTING: ON
-- FP64: ON
-- FP32: OFF
-- Configuring done
CMake Error at src/CMakeLists.txt:26 (add_library):
  Target "pumipic-core" links to target "MPI::MPI_CXX" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
```
and error duding `make`:
```
[ 64%] Linking CXX executable loadSerialMesh
/opt/rh/devtoolset-7/root/usr/libexec/gcc/x86_64-redhat-linux/7/ld: cannot find -lMPI::MPI_CXX
collect2: error: ld returned 1 exit status
make[2]: *** [test/CMakeFiles/search2d.dir/build.make:116: test/search2d] Error 1
make[1]: *** [CMakeFiles/Makefile2:714: test/CMakeFiles/search2d.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```