### PR TITLE
Use particle name in CabM timing output

### DIFF
--- a/particle_structs/src/cabm/cabm.hpp
+++ b/particle_structs/src/cabm/cabm.hpp
@@ -196,7 +196,7 @@ namespace pumipic {
     int comm_rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
     if(!comm_rank)
-      fprintf(stderr, "building CabM\n");
+      fprintf(stderr, "building CabM for %s\n", name.c_str());
     
     // build view of offsets for SoA indices within particle elements
     offsets = buildOffset(input.ppe, num_ptcls, extra_padding, padding_start);

--- a/particle_structs/src/cabm/cabm_migrate.hpp
+++ b/particle_structs/src/cabm/cabm_migrate.hpp
@@ -27,7 +27,7 @@ namespace pumipic {
 
     // If serial, skip migration
     if (comm_size == 1) {
-      RecordTime("CabM particle migration", timer.seconds(), btime);
+      RecordTime(name + " particle migration", timer.seconds(), btime);
       rebuild(new_element, new_particle_elements, new_particle_info);
       Kokkos::Profiling::popRegion();
       return;
@@ -127,7 +127,7 @@ namespace pumipic {
     if (num_sending_to == 0 && num_receiving_from == 0) {
       destroyViews<DataTypes, memory_space>(send_particle);
       rebuild(new_element, new_particle_elements, new_particle_info);
-      RecordTime("CabM particle migration", timer.seconds(), btime);
+      RecordTime(name + " particle migration", timer.seconds(), btime);
       Kokkos::Profiling::popRegion();
       return;
     }
@@ -221,7 +221,7 @@ namespace pumipic {
     destroyViews<DataTypes, memory_space>(send_particle);
     destroyViews<DataTypes, memory_space>(recv_particle);
     
-    RecordTime("CabM particle migration", timer.seconds() - temp, btime);
+    RecordTime(name +" particle migration", timer.seconds() - temp, btime);
 
     Kokkos::Profiling::popRegion();
   }

--- a/particle_structs/src/cabm/cabm_rebuild.hpp
+++ b/particle_structs/src/cabm/cabm_rebuild.hpp
@@ -55,7 +55,7 @@ namespace pumipic {
         particle_indices(ptcl) = Kokkos::atomic_fetch_add(&elmDegree_d(parent),1);
       });
 
-    RecordTime("CabM count active particles", overall_timer.seconds());
+    RecordTime(name + " count active particles", overall_timer.seconds());
     Kokkos::Timer setup_timer; // timer for aosoa setup
 
     // prepare a new aosoa to store the shuffled particles
@@ -77,7 +77,7 @@ namespace pumipic {
       newAosoa = aosoa_swap;
     }
 
-    RecordTime("CabM move/destroy setup", setup_timer.seconds());
+    RecordTime(name + " move/destroy setup", setup_timer.seconds());
     Kokkos::Timer existing_timer; // timer for moving/deleting particles
 
     kkLidView elmPtclCounter_d("elmPtclCounter_device", num_elems);
@@ -120,7 +120,7 @@ namespace pumipic {
     parentElms_ = getParentElms(num_elems, num_soa_, offsets);
     setActive(elmDegree_d);
 
-    RecordTime("CabM move/destroy existing particles", existing_timer.seconds());
+    RecordTime(name + " move/destroy existing particles", existing_timer.seconds());
     Kokkos::Timer add_timer; // timer for adding particles
 
     // add new particles
@@ -139,8 +139,8 @@ namespace pumipic {
         soa_indices, soa_ptcl_indices); // copy data over
     }
 
-    RecordTime("CabM add particles", add_timer.seconds());
-    RecordTime("CabM rebuild", overall_timer.seconds(), btime);
+    RecordTime(name + " add particles", add_timer.seconds());
+    RecordTime(name + " rebuild", overall_timer.seconds(), btime);
     Kokkos::Profiling::popRegion();
   }
 


### PR DESCRIPTION
Use particle structure name, instead of generic `CabM` in timing output, to distinguish between different particle types: `ions`, `electrons`, etc.