### PR TITLE
Small bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,15 @@ bob_public_dep(EnGPar)
 
 option(ENABLE_CABANA "Build with Cabana" OFF)
 if(ENABLE_CABANA)
-  if(Cabana_VERSION VERSION_LESS 0.6.0)
-    message(FATAL_ERROR "Cabana version >= 0.6.0 required.")
-  endif()
   # bob package creation { no idea if this will work
   set(pumipic_USE_Cabana_DEFAULT ON)
   set(Cabana_PREFIX ${Cabana_PREFIX})
   bob_public_dep(Cabana)
   # }
   add_definitions(-DPP_ENABLE_CAB)
+  if(Cabana_VERSION VERSION_LESS 0.6.0 OR Cabana_VERSION STREQUAL "1.0-dev")
+    message(FATAL_ERROR "Cabana version >= 0.6.0 required.")
+  endif()
 endif()
 
 set(pumipic_USE_Kokkos_DEFAULT ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,15 @@ bob_public_dep(EnGPar)
 
 option(ENABLE_CABANA "Build with Cabana" OFF)
 if(ENABLE_CABANA)
+  if(Cabana_VERSION VERSION_LESS 0.6.0)
+    message(FATAL_ERROR "Cabana version >= 0.6.0 required.")
+  endif()
   # bob package creation { no idea if this will work
   set(pumipic_USE_Cabana_DEFAULT ON)
   set(Cabana_PREFIX ${Cabana_PREFIX})
   bob_public_dep(Cabana)
   # }
   add_definitions(-DPP_ENABLE_CAB)
-  if(Cabana_VERSION VERSION_LESS 0.6.0)
-    message(FATAL_ERROR "Cabana version >= 0.6.0 required.")
-  endif()
 endif()
 
 set(pumipic_USE_Kokkos_DEFAULT ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
 
-project(pumipic VERSION 2.0.1 LANGUAGES CXX)
+project(pumipic VERSION 2.0.2 LANGUAGES CXX)
 
 include(cmake/bob.cmake)
 

--- a/particle_structs/src/scs/SCS_sort.h
+++ b/particle_structs/src/scs/SCS_sort.h
@@ -15,6 +15,7 @@ namespace pumipic {
         index(i) = i;
       });
 
+      sigma = std::min(sigma, std::max(num_elems, 1));
       lid_t n_sigma = num_elems/sigma;
       Kokkos::parallel_for( PolicyType(n_sigma, 1), KOKKOS_LAMBDA(const TeamMem& t){
         lid_t start = t.league_rank() * sigma;

--- a/particle_structs/test/test_structure.cpp
+++ b/particle_structs/test/test_structure.cpp
@@ -117,7 +117,7 @@ PS* buildNextStructure(int num, lid_t num_elems, lid_t num_ptcls, kkLidView ppe,
       //Build SCS with C = 32, sigma = ne, V = 1024
       error_message = "SCS (C=32, sigma=ne, V=1024)";
       lid_t maxC = 32;
-      lid_t sigma = num_elems;
+      lid_t sigma = INT_MAX;
       lid_t V = 1024;
       Kokkos::TeamPolicy<ExeSpace> policy = pumipic::TeamPolicyAuto(4, maxC);
       name = "scs_C32_SMAX_V1024";


### PR DESCRIPTION
Bugs Fixed:
- Before Cabana 0.6.0 all of the versions were marked as 1.0.0-dev.
- SCS sorting did not work for sigma > num_elms.