### PR TITLE
bug-fix - move thrust sort assertion inside CUDA

### DIFF
--- a/particle_structs/test/sortTest.cpp
+++ b/particle_structs/test/sortTest.cpp
@@ -74,11 +74,11 @@ void performSorting(Kokkos::View<int*> arr, int sigma, const char* name) {
   thrustSigmaSort(thrustSorted, thrustIndex, arr.size(), arr, sigma);
   Kokkos::fence();
   printf("Thrust %s sort time: %.6f\n", name, t.seconds());
-  #endif
 
   Kokkos::parallel_for( arr.size(), KOKKOS_LAMBDA(const lid_t& i) {
     assert(thrustSorted(i) == kokkosSorted(i));
   });
+  #endif
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
If compiled with Kokkos SERIAL, `/particle_structs/test/sortTest.cpp` doesn't compile and throws the following error:
```bash
/lore/hasanm4/wsources/pumirelated/pumi-pic/particle_structs/test/sortTest.cpp: In lambda function:
/lore/hasanm4/wsources/pumirelated/pumi-pic/particle_structs/test/sortTest.cpp:80:12: error: 'thrustSorted' was not declared in this scope
   80 |     assert(thrustSorted(i) == kokkosSorted(i));
      |            ^~~~~~~~~~~~
gmake[2]: *** [particle_structs/test/CMakeFiles/sortTest.dir/build.make:76: particle_structs/test/CMakeFiles/sortTest.dir/sortTest.cpp.o] Error 1
```

I have moved this assertion inside the `PP_USE_CUDA` section.