### PR TITLE
Pass elmArea as parameter

### DIFF
--- a/src/pumipic_adjacency.tpp
+++ b/src/pumipic_adjacency.tpp
@@ -455,6 +455,7 @@ namespace pumipic {
   * @param looplimit Maximum number of iterations
   * @param debug True if debug information is printed
   * @param func Callable object to handle particles at element sides or destination
+  * @param elmArea Element areas/volumes based on the mesh dimension
   * @param given_tol Tolerance for intersection. If not positive, it is computed from the minimum element area
   * @return True if all particles are found at destination or left domain
   */
@@ -468,6 +469,7 @@ namespace pumipic {
                    int looplimit,
                    bool debug,
                    Func& func,
+                   o::Reals& elmArea,
                    std::optional<o::Real> given_tol = std::nullopt) {
     static_assert(
         std::is_invocable_r_v<
@@ -488,7 +490,6 @@ namespace pumipic {
     o::Write<o::LO> ptcl_done(psCapacity, 0, "search_ptcl_done");
     // Store the last exit face
     o::Write<o::LO> lastExit(psCapacity,-1, "search_last_exit");
-    const auto elmArea = measure_elements_real(&mesh);
     bool useBcc = !requireIntersection;
 
     o::Real tol = 0;
@@ -656,8 +657,9 @@ namespace pumipic {
                    int looplimit,
                    int debug) {
     RemoveParticleOnGeometricModelExit<ParticleType, Segment3d> native_handler(mesh, requireIntersection);
+    o::Reals elmArea = measure_elements_real(&mesh);
     return trace_particle_through_mesh(mesh, ptcls, x_ps_orig, x_ps_tgt, pids, elem_ids, requireIntersection,
-                           inter_faces, inter_points, looplimit, debug, native_handler);
+                           inter_faces, inter_points, looplimit, debug, native_handler, elmArea);
   }
 }
 #endif

--- a/src/pumipic_adjacency.tpp
+++ b/src/pumipic_adjacency.tpp
@@ -466,7 +466,8 @@ namespace pumipic {
                    o::Write<o::Real>& inter_points,
                    int looplimit,
                    bool debug,
-                   Func& func) {
+                   Func& func,
+                   o::Real tol = -1.0) {
     static_assert(
         std::is_invocable_r_v<
             void, Func, o::Mesh &, ParticleStructure<ParticleType> *,
@@ -488,7 +489,10 @@ namespace pumipic {
     o::Write<o::LO> lastExit(psCapacity,-1, "search_last_exit");
     const auto elmArea = measure_elements_real(&mesh);
     bool useBcc = !requireIntersection;
-    o::Real tol = compute_tolerance_from_area(elmArea);
+
+    if (tol < 0) {
+        tol = compute_tolerance_from_area(elmArea);
+    }
     
     int rank;
     MPI_Comm_rank(mesh.comm()->get_impl(), &rank);

--- a/src/pumipic_adjacency.tpp
+++ b/src/pumipic_adjacency.tpp
@@ -455,6 +455,7 @@ namespace pumipic {
   * @param looplimit Maximum number of iterations
   * @param debug True if debug information is printed
   * @param func Callable object to handle particles at element sides or destination
+  * @param tol Tolerance for intersection. If not positive, it is computed from the minimum element area
   * @return True if all particles are found at destination or left domain
   */
   template <class ParticleType, typename Segment3d, typename SegmentInt, typename Func>
@@ -467,7 +468,7 @@ namespace pumipic {
                    int looplimit,
                    bool debug,
                    Func& func,
-                   o::Real tol = -1.0) {
+                   o::Real &tol) {
     static_assert(
         std::is_invocable_r_v<
             void, Func, o::Mesh &, ParticleStructure<ParticleType> *,
@@ -490,7 +491,7 @@ namespace pumipic {
     const auto elmArea = measure_elements_real(&mesh);
     bool useBcc = !requireIntersection;
 
-    if (tol < 0) {
+    if (tol <= 0.0) {
         tol = compute_tolerance_from_area(elmArea);
     }
     
@@ -652,9 +653,9 @@ namespace pumipic {
                    int looplimit,
                    int debug) {
     RemoveParticleOnGeometricModelExit<ParticleType, Segment3d> native_handler(mesh, requireIntersection);
-
+    o::Real tol = -1.0;
     return trace_particle_through_mesh(mesh, ptcls, x_ps_orig, x_ps_tgt, pids, elem_ids, requireIntersection,
-                           inter_faces, inter_points, looplimit, debug, native_handler);
+                           inter_faces, inter_points, looplimit, debug, native_handler, tol);
   }
 }
 #endif


### PR DESCRIPTION
`elmArea` is computed using the function `measure_elements_real`. Users may want to cache the information and avoid computing it in every search.

Note: `tol` is related to `elmArea` and I have added your suggested changes here for `tol` in pull request #141