### PR TITLE
Fixed deprecation warning related to mallinfo during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL 
   include(CheckCXXSymbolExists)
   check_cxx_symbol_exists(mallinfo2 "malloc.h" PUMIPIC_HAS_MALLINFO2)
   if(PUMIPIC_HAS_MALLINFO2)
-    target_compile_definitions(support INTERFACE -DPUMIPIC_HAS_MALLINFO2)
+    target_compile_definitions(support PUBLIC -DPUMIPIC_HAS_MALLINFO2)
   endif()
 endif()
 


### PR DESCRIPTION
`mallinfo`is used in both the support target and other dependent targets, so it should be set as PUBLIC rather than INTERFACE.