### PR TITLE
Replace boolean mask in particale structure with integer

### DIFF
--- a/particle_structs/src/cabm/cabm.hpp
+++ b/particle_structs/src/cabm/cabm.hpp
@@ -32,7 +32,7 @@ namespace pumipic {
     typedef CabM_Input<DataTypes, MemSpace> Input_T;
 
     //from https://github.com/SCOREC/Cabana/blob/53ad18a030f19e0956fd0cab77f62a9670f31941/core/src/CabanaM.hpp#L18-L19
-    using CM_DT = PS_DTBool<DataTypes>;
+    using CM_DT = PS_DTInt<DataTypes>;
     using AoSoA_t = Cabana::AoSoA<CM_DT,memory_space>;
 
     CabM(const CabM&) = delete;

--- a/particle_structs/src/cabm/cabm_migrate.hpp
+++ b/particle_structs/src/cabm/cabm_migrate.hpp
@@ -35,7 +35,7 @@ namespace pumipic {
 
     // Count number of particles to send to each process
     kkLidView num_send_particles("num_send_particles", comm_size + 1);
-    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && (process != comm_rank)) {
         const lid_t process_index = dist.index(process);
@@ -88,7 +88,7 @@ namespace pumipic {
     CreateViews<device_type, DataTypes>(send_particle, np_send);
     kkLidView send_index(Kokkos::ViewAllocateWithoutInitializing("send_particle_index"), capacity());
     auto element_to_gid_local = element_to_gid;
-    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && process != comm_rank) {
         const lid_t process_index = dist.index(process);
@@ -196,7 +196,7 @@ namespace pumipic {
       });
 
     // ********** Set particles that were sent to non existent on this process *********
-    auto removeSentParticles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto removeSentParticles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const bool sent = new_process(particle_id) != comm_rank;
       const lid_t elm = new_element(particle_id);
       // Subtract (its value + 1) to get to -1 if it was sent, 0 otherwise

--- a/particle_structs/src/csr/CSR.hpp
+++ b/particle_structs/src/csr/CSR.hpp
@@ -201,9 +201,9 @@ namespace pumipic {
         const lid_t numPtcls = end-start;
         Kokkos::parallel_for(Kokkos::TeamThreadRange(thread, numPtcls), [=] (lid_t& j) {
           const lid_t particle_id = start+j;
-          bool mask = true;
+          lid_t mask = 1;
           if (particle_id > num_ptcls_cpy)
-            mask = false;
+            mask = 0;
           (*fn_d)(elm, particle_id, mask);
         });
     });

--- a/particle_structs/src/csr/CSR_buildFns.hpp
+++ b/particle_structs/src/csr/CSR_buildFns.hpp
@@ -42,7 +42,7 @@ namespace pumipic {
 
     // atomic_fetch_add to increment from the beginning of each element
     // when filling (offset[element] is start of element)
-    auto fill_ptcl_indices = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, bool& mask){
+    auto fill_ptcl_indices = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, lid_t& mask){
       particle_indices(ptcl_id) = Kokkos::atomic_fetch_add(&row_indices(particle_elements(ptcl_id)),1);
     };
     parallel_for(fill_ptcl_indices);

--- a/particle_structs/src/csr/CSR_migrate.hpp
+++ b/particle_structs/src/csr/CSR_migrate.hpp
@@ -35,7 +35,7 @@ namespace pumipic {
 
     // Count number of particles to send to each process
     kkLidView num_send_particles("num_send_particles", comm_size + 1);
-    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && (process != comm_rank)) {
         const lid_t process_index = dist.index(process);
@@ -87,7 +87,7 @@ namespace pumipic {
     CreateViews<device_type, DataTypes>(send_particle, np_send);
     kkLidView send_index(Kokkos::ViewAllocateWithoutInitializing("send_particle_index"), capacity());
     auto element_to_gid_local = element_to_gid;
-    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && process != comm_rank) {
         const lid_t process_index = dist.index(process);

--- a/particle_structs/src/csr/CSR_rebuild.hpp
+++ b/particle_structs/src/csr/CSR_rebuild.hpp
@@ -28,7 +28,7 @@ namespace pumipic {
     kkLidView particles_per_element = kkLidView("particlesPerElement", num_elems+1);
     kkLidView num_removed_d("num_removed_d",1);
     // Fill ptcls per elem for existing ptcls
-    auto count_existing = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, const bool& mask) {
+    auto count_existing = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, const lid_t& mask) {
       if (new_element[ptcl_id] > -1)
         Kokkos::atomic_increment(&particles_per_element[new_element[ptcl_id]]);
       else
@@ -56,7 +56,7 @@ namespace pumipic {
     Kokkos::deep_copy(row_indices,offsets_new);
     kkLidView new_indices(Kokkos::ViewAllocateWithoutInitializing("new indices"), new_element.size());
 
-    auto existing_ptcl_new_indices = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, const bool& mask) {
+    auto existing_ptcl_new_indices = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, const lid_t& mask) {
       const lid_t new_elem = new_element[ptcl_id];
       if (new_elem != -1)
         new_indices[ptcl_id] = Kokkos::atomic_fetch_add(&row_indices(new_elem),1);

--- a/particle_structs/src/dps/dps.hpp
+++ b/particle_structs/src/dps/dps.hpp
@@ -32,7 +32,7 @@ namespace pumipic {
     typedef Kokkos::UnorderedMap<gid_t, lid_t, device_type> GID_Mapping;
     typedef DPS_Input<DataTypes, MemSpace> Input_T;
 
-    using DPS_DT = PS_DTBool<DataTypes>;
+    using DPS_DT = PS_DTInt<DataTypes>;
     using AoSoA_t = Cabana::AoSoA<DPS_DT,memory_space>;
 
     DPS(const DPS&) = delete;

--- a/particle_structs/src/dps/dps_migrate.hpp
+++ b/particle_structs/src/dps/dps_migrate.hpp
@@ -35,7 +35,7 @@ namespace pumipic {
     
     // Count number of particles to send to each process
     kkLidView num_send_particles("num_send_particles", comm_size + 1);
-    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && (process != comm_rank)) {
         const lid_t process_index = dist.index(process);
@@ -87,7 +87,7 @@ namespace pumipic {
     CreateViews<device_type, DataTypes>(send_particle, np_send);
     kkLidView send_index(Kokkos::ViewAllocateWithoutInitializing("send_particle_index"), capacity());
     auto element_to_gid_local = element_to_gid;
-    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && process != comm_rank) {
         const lid_t process_index = dist.index(process);
@@ -193,7 +193,7 @@ namespace pumipic {
       });
     
     // ********** Set particles that were sent to non existent on this process *********
-    auto removeSentParticles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto removeSentParticles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const bool sent = new_process(particle_id) != comm_rank;
       const lid_t elm = new_element(particle_id);
       // Subtract (its value + 1) to get to -1 if it was sent, 0 otherwise

--- a/particle_structs/src/particle_structure.hpp
+++ b/particle_structs/src/particle_structure.hpp
@@ -47,7 +47,7 @@ namespace pumipic {
       typename std::remove_all_extents<DataType<M>>::type;
 
 #ifdef PP_ENABLE_CAB
-    using PS_DT=PS_DTBool<Types>;
+    using PS_DT=PS_DTInt<Types>;
     using soa_type = Cabana::SoA<PS_DT, vector_length>;
     template <std::size_t N> using Slice =
       Segment<DataType<N>, memory_space, Cabana::DefaultAccessMemory, vector_length,

--- a/particle_structs/src/ps_for.hpp
+++ b/particle_structs/src/ps_for.hpp
@@ -65,7 +65,7 @@ namespace pumipic {
   void ParticleStructure<DataTypes, MemSpace>::getPIDs(ViewT& pids, ViewT& offsets) {
     offsets = ViewT("offsets", num_elems+1);
     ViewT ppe("ppe", num_elems+1);
-    auto setPPE = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+    auto setPPE = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
       if (mask) {
         Kokkos::atomic_increment(&ppe(e));
       }
@@ -75,7 +75,7 @@ namespace pumipic {
     
     pids = ViewT("pids", getLastValue(offsets));
     ViewT currIndex("currIndex", num_elems);
-    auto setPIDs = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+    auto setPIDs = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
       if (mask) {
         auto index = Kokkos::atomic_fetch_add(&currIndex(e), 1);
         pids(offsets(e)+index) = p;

--- a/particle_structs/src/scs/SCS_buildFns.h
+++ b/particle_structs/src/scs/SCS_buildFns.h
@@ -152,7 +152,7 @@ namespace pumipic {
     cap = getLastValue(offs);
   }
   template<class DataTypes, typename MemSpace>
-  void SellCSigma<DataTypes, MemSpace>::setupParticleMask(Kokkos::View<bool*> mask,
+  void SellCSigma<DataTypes, MemSpace>::setupParticleMask(Kokkos::View<lid_t*> mask,
                                                           kkLidView ptcls,
                                                           kkLidView chunk_widths,
                                                           kkLidView& chunk_starts) {
@@ -192,7 +192,7 @@ namespace pumipic {
               if (element_id < ne)
                 mask(particle_id) = p < ptcls(row);
 	      else
-		mask(particle_id) = false;
+		mask(particle_id) = 0;
             });
         });
     });

--- a/particle_structs/src/scs/SCS_migrate.h
+++ b/particle_structs/src/scs/SCS_migrate.h
@@ -27,7 +27,7 @@ namespace pumipic {
 
     //Count number of particles to send to each process
     kkLidView num_send_particles("num_send_particles", comm_size + 1);
-    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto count_sending_particles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && (process != comm_rank)) {
         const lid_t process_index = dist.index(process);
@@ -80,7 +80,7 @@ namespace pumipic {
     CreateViews<device_type, DataTypes>(send_particle, np_send);
     kkLidView send_index(Kokkos::ViewAllocateWithoutInitializing("send_particle_index"), capacity());
     auto element_to_gid_local = element_to_gid;
-    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto gatherParticlesToSend = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const lid_t process = new_process(particle_id);
       if (mask && process != comm_rank) {
         const lid_t process_index = dist.index(process);
@@ -187,7 +187,7 @@ namespace pumipic {
       });
 
     /********** Set particles that were sent to non existent on this process *********/
-    auto removeSentParticles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const bool& mask) {
+    auto removeSentParticles = PS_LAMBDA(const lid_t& element_id, const lid_t& particle_id, const lid_t& mask) {
       const bool sent = new_process(particle_id) != comm_rank;
       const lid_t elm = new_element(particle_id);
       //Subtract (its value + 1) to get to -1 if it was sent, 0 otherwise

--- a/particle_structs/src/scs/SellCSigma.h
+++ b/particle_structs/src/scs/SellCSigma.h
@@ -150,7 +150,7 @@ template <std::size_t N> using Slice = Segment<DataType<N>, device_type>;
   void createGlobalMapping(kkGidView elmGid, kkGidView& elm2Gid, GID_Mapping& elmGid2Lid);
   void constructOffsets(lid_t nChunks, lid_t& nSlices, kkLidView chunk_widths,
                         kkLidView& offs, kkLidView& s2e, lid_t& capacity);
-  void setupParticleMask(Kokkos::View<bool*> mask, kkLidView ptcls, kkLidView chunk_widths,
+  void setupParticleMask(Kokkos::View<lid_t*> mask, kkLidView ptcls, kkLidView chunk_widths,
                          kkLidView& chunk_starts);
   void initSCSData(kkLidView chunk_widths, kkLidView particle_elements,
                    MTVs particle_info);
@@ -186,7 +186,7 @@ template <std::size_t N> using Slice = Segment<DataType<N>, device_type>;
   //  it is a part of.
   kkLidView slice_to_chunk;
   //particle_mask true means there is a particle at this location, false otherwise
-  Kokkos::View<bool*, MemSpace> particle_mask;
+  Kokkos::View<lid_t*, MemSpace> particle_mask;
   //offsets into the scs structure
   kkLidView offsets;
 
@@ -263,7 +263,7 @@ void SellCSigma<DataTypes, MemSpace>::construct(kkLidView ptcls_per_elem,
 
   //Allocate the SCS and backup with extra space
   lid_t cap = capacity_;
-  particle_mask = Kokkos::View<bool*>(Kokkos::ViewAllocateWithoutInitializing("particle_mask"), cap);
+  particle_mask = Kokkos::View<lid_t*>(Kokkos::ViewAllocateWithoutInitializing("particle_mask"), cap);
   if (extra_padding > 0)
     cap *= (1 + extra_padding);
   CreateViews<device_type, DataTypes>(ptcl_data, cap);
@@ -367,7 +367,7 @@ typename SellCSigma<DataTypes, MemSpace>::template Mirror<MSpace>* SellCSigma<Da
   mirror_copy->slice_to_chunk = typename Mirror<MSpace>::kkLidView("mirror slice_to_chunk",
                                                                    slice_to_chunk.size());
   Kokkos::deep_copy(mirror_copy->slice_to_chunk, slice_to_chunk);
-  mirror_copy->particle_mask = Kokkos::View<bool*,MSpace>("mirror particle_mask",
+  mirror_copy->particle_mask = Kokkos::View<lid_t*,MSpace>("mirror particle_mask",
                                                                   particle_mask.size());
   Kokkos::deep_copy(mirror_copy->particle_mask, particle_mask);
   mirror_copy->offsets = typename Mirror<MSpace>::kkLidView("mirror offsets", offsets.size());
@@ -407,7 +407,7 @@ void SellCSigma<DataTypes,MemSpace>::printFormat(const char* prefix) const {
   kkGidHostMirror element_to_gid_host = deviceToHost(element_to_gid);
   kkLidHostMirror row_to_element_host = deviceToHost(row_to_element);
   kkLidHostMirror offsets_host = deviceToHost(offsets);
-  Kokkos::View<bool*>::HostMirror particle_mask_host = deviceToHost(particle_mask);
+  Kokkos::View<lid_t*>::HostMirror particle_mask_host = deviceToHost(particle_mask);
 
   std::stringstream ss;
   char buffer[1000];
@@ -486,7 +486,7 @@ void SellCSigma<DataTypes, MemSpace>::printMetrics(MPI_Comm mpi_comm) const {
     lid_t np = 0;
     for (lid_t p = 0; p < rowLen; ++p) {
       const lid_t particle_id = start+(p*team_size);
-      const bool mask = particle_mask_cpy(particle_id);
+      const lid_t mask = particle_mask_cpy(particle_id);
       np += !mask;
     }
     Kokkos::atomic_fetch_add(&padded_cells[0],np);
@@ -547,7 +547,7 @@ void SellCSigma<DataTypes, MemSpace>::parallel_for(FunctionType& fn, std::string
       const lid_t element_id = row_to_element_cpy(row);
       Kokkos::parallel_for(Kokkos::ThreadVectorRange(thread, rowLen), [=] (lid_t& p) {
         const lid_t particle_id = start+(p*team_size);
-        const bool mask = particle_mask_cpy(particle_id);
+        const lid_t mask = particle_mask_cpy(particle_id);
         (*fn_d)(element_id, particle_id, mask);
       });
     });

--- a/particle_structs/src/support/psMemberType.h
+++ b/particle_structs/src/support/psMemberType.h
@@ -48,7 +48,7 @@ namespace pumipic {
       MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
       MemberTypeView<T, Device> dst = *static_cast<MemberTypeView<T, Device> const*>(dsts[0]);
       MemberTypeView<T, Device> src = *static_cast<MemberTypeView<T, Device> const*>(srcs[0]);
-      auto copyPSToArray = PS_LAMBDA(int elm_id, int ptcl_id, bool mask) {
+      auto copyPSToArray = PS_LAMBDA(int elm_id, int ptcl_id, int mask) {
         const int arr_index = ps_to_array(ptcl_id);
         if (mask && arr_index != comm_rank) {
           const int index = array_indices(ptcl_id);
@@ -92,7 +92,7 @@ namespace pumipic {
                  typename PS::kkLidView ps_indices) {
       MemberTypeView<T, Device> dst = *static_cast<MemberTypeView<T, Device> const*>(dsts[0]);
       MemberTypeView<T, Device> src = *static_cast<MemberTypeView<T, Device> const*>(srcs[0]);
-      auto copyPSToPS = PS_LAMBDA(int elm_id, int ptcl_id, bool mask) {
+      auto copyPSToPS = PS_LAMBDA(int elm_id, int ptcl_id, int mask) {
         const lid_t new_elem = new_element(ptcl_id);
         if (mask && new_elem != -1) {
           const int index = ps_indices(ptcl_id);

--- a/particle_structs/src/support/psMemberTypeCabana.h
+++ b/particle_structs/src/support/psMemberTypeCabana.h
@@ -25,7 +25,7 @@ namespace pumipic {
     static constexpr int size = 1 + Cabana::MemberTypes<Types...>::size;
     using type = Cabana::MemberTypes<Types..., T>; //Put T before Types... to put at beginning
   };
-  template <typename DataTypes> using PS_DTInt = typename AppendMT<int,DataTypes>::type;
+  template <typename DataTypes> using PS_DTInt = typename AppendMT<lid_t,DataTypes>::type;
 
   template <typename ViewT, std::size_t Rank>
   using CheckRank = typename std::enable_if<(ViewT::rank == Rank), void>::type;

--- a/particle_structs/src/support/psMemberTypeCabana.h
+++ b/particle_structs/src/support/psMemberTypeCabana.h
@@ -25,7 +25,7 @@ namespace pumipic {
     static constexpr int size = 1 + Cabana::MemberTypes<Types...>::size;
     using type = Cabana::MemberTypes<Types..., T>; //Put T before Types... to put at beginning
   };
-  template <typename DataTypes> using PS_DTBool = typename AppendMT<bool,DataTypes>::type;
+  template <typename DataTypes> using PS_DTInt = typename AppendMT<int,DataTypes>::type;
 
   template <typename ViewT, std::size_t Rank>
   using CheckRank = typename std::enable_if<(ViewT::rank == Rank), void>::type;
@@ -104,8 +104,8 @@ namespace pumipic {
   struct CopyMTVsToAoSoA<PS, MemberTypes<Types...>> {
     typedef typename PS::device_type Device;
     typedef typename PS::memory_space memory_space;
-    typedef Cabana::AoSoA<PS_DTBool<MemberTypes<Types...>>, memory_space> Aosoa;
-    typedef PS_DTBool<MemberTypes<Types...>> CM_DT;
+    typedef Cabana::AoSoA<PS_DTInt<MemberTypes<Types...>>, memory_space> Aosoa;
+    typedef PS_DTInt<MemberTypes<Types...>> CM_DT;
 
     CopyMTVsToAoSoA(Aosoa &dst, MemberTypeViewsConst src,
                     typename PS::kkLidView soa_indices,
@@ -195,8 +195,8 @@ namespace pumipic {
   struct CopyParticlesToSendFromAoSoA<PS, MemberTypes<Types...> > {
     typedef typename PS::device_type Device;
     typedef typename PS::memory_space memory_space;
-    typedef Cabana::AoSoA<PS_DTBool<MemberTypes<Types...>>, memory_space> Aosoa;
-    typedef PS_DTBool<MemberTypes<Types...>> CM_DT;
+    typedef Cabana::AoSoA<PS_DTInt<MemberTypes<Types...>>, memory_space> Aosoa;
+    typedef PS_DTInt<MemberTypes<Types...>> CM_DT;
 
     CopyParticlesToSendFromAoSoA(PS* ps, MemberTypeViews dsts, const Aosoa &src,
                         typename PS::kkLidView ps_to_array,

--- a/particle_structs/src/support/psMemberTypeCabana.h
+++ b/particle_structs/src/support/psMemberTypeCabana.h
@@ -25,6 +25,8 @@ namespace pumipic {
     static constexpr int size = 1 + Cabana::MemberTypes<Types...>::size;
     using type = Cabana::MemberTypes<Types..., T>; //Put T before Types... to put at beginning
   };
+  //The integer type appended to PS_DTInt are actually used as a boolean mask
+  //The reason to do this is related to Cabana issue 842
   template <typename DataTypes> using PS_DTInt = typename AppendMT<lid_t,DataTypes>::type;
 
   template <typename ViewT, std::size_t Rank>

--- a/particle_structs/test/Distribute.h
+++ b/particle_structs/test/Distribute.h
@@ -32,7 +32,7 @@ bool redistribute_particles(PS* ptcls, int strat, double percentMoved,
   assert(percentMoved <= 1);
   Kokkos::Random_XorShift64_Pool<typename PS::execution_space> pool(DISTRIBUTE_SEED);
   typename PS::kkLidView is_moving("is_moving", ptcls->capacity());
-  auto decideMovers = PS_LAMBDA(const int e, const int p, const bool mask) {
+  auto decideMovers = PS_LAMBDA(const int e, const int p, const int mask) {
     if (mask) {
       auto generator = pool.get_state();
       double prob = generator.drand(1.0);
@@ -60,7 +60,7 @@ bool redistribute_particles(PS* ptcls, int strat, double percentMoved,
   typename PS::kkLidView new_ppe("new_ppe", numElems);
   typename PS::kkLidView new_moves_d("new_moves", total);
   distribute_particles(numElems, total, strat, new_ppe, new_moves_d);
-  auto assignMoves = PS_LAMBDA(const int e, const int p, const bool mask) {
+  auto assignMoves = PS_LAMBDA(const int e, const int p, const int mask) {
     if (mask) {
       if (is_moving[p]) {
         int index = mover_index[p];

--- a/particle_structs/test/initParticles.cpp
+++ b/particle_structs/test/initParticles.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     scs->printFormat();
     SCS::kkLidView fail("fail",1);
     auto elem_scs = scs->get<0>();
-    auto check = PS_LAMBDA(const int eid, const int pid, const bool mask) {
+    auto check = PS_LAMBDA(const int eid, const int pid, const int mask) {
       if (mask && (eid != elem_scs(pid))) {
         printf("Particle %d is not assigned to the correct element (%d != %d)\n", pid,
                eid, elem_scs(pid));

--- a/particle_structs/test/scs_padding.cpp
+++ b/particle_structs/test/scs_padding.cpp
@@ -73,7 +73,7 @@ bool padEvenly(Input& input) {
          (lid_t)(scs->nPtcls() * (1.0 + input.shuffle_padding)));
   scs->printMetrics();
   auto vals = scs->get<0>();
-  auto lamb = PS_LAMBDA(const lid_t& elem, const lid_t& ptcl, const bool& mask) {
+  auto lamb = PS_LAMBDA(const lid_t& elem, const lid_t& ptcl, const lid_t& mask) {
     vals(ptcl) = mask;
   };
   ps::parallel_for(scs, lamb, "pad_evenly");
@@ -88,7 +88,7 @@ bool padProportionally(Input& input) {
          scs->capacity(), (lid_t)(scs->nPtcls() * (1.0 + input.shuffle_padding)));
   scs->printMetrics();
   auto vals = scs->get<0>();
-  auto lamb = PS_LAMBDA(const lid_t& elem, const lid_t& ptcl, const bool& mask) {
+  auto lamb = PS_LAMBDA(const lid_t& elem, const lid_t& ptcl, const lid_t& mask) {
     vals(ptcl) = mask;
   };
   ps::parallel_for(scs, lamb, "pad_proportionally");
@@ -103,7 +103,7 @@ bool padInversely(Input& input) {
          scs->capacity(), (lid_t)(scs->nPtcls() * (1.0 + input.shuffle_padding)));
   scs->printMetrics();
   auto vals = scs->get<0>();
-  auto lamb = PS_LAMBDA(const lid_t& elem, const lid_t& ptcl, const bool& mask) {
+  auto lamb = PS_LAMBDA(const lid_t& elem, const lid_t& ptcl, const lid_t& mask) {
     vals(ptcl) = mask;
   };
   ps::parallel_for(scs, lamb, "pad_inversely");

--- a/particle_structs/test/smoke_test_particle.cpp
+++ b/particle_structs/test/smoke_test_particle.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) {
 
 void testStructure(PS* structure, int comm_rank, int comm_size, kkLidView failures) {
   //Init
-  auto checkInit = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkInit = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask && e != p){
       printf("Structure not initalized at Particle: %d, Elm: %d\n", p, e);
       failures(0) = 1;
@@ -69,14 +69,14 @@ void testStructure(PS* structure, int comm_rank, int comm_size, kkLidView failur
 
   //Rebuild
   kkLidView new_element("new_element", structure->capacity());
-  auto setNewElm = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setNewElm = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) new_element(p) = comm_rank;
     else new_element(p) = -1;
   };
   ps::parallel_for(structure, setNewElm, "setNewElm");
   structure->rebuild(new_element);
 
-  auto checkRebuild = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkRebuild = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask && e != comm_rank){
       printf("Structure failed to rebuild at Ptcl: %d, Elm: %d\n", p, e);
       failures(0) = 1;
@@ -86,14 +86,14 @@ void testStructure(PS* structure, int comm_rank, int comm_size, kkLidView failur
 
   //Migrate
   kkLidView new_process("new_process", structure->capacity());
-  auto setNewProcess = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setNewProcess = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) new_process(p) = (comm_rank + 1) % comm_size;
     else new_process(p) = comm_rank;
   };
   ps::parallel_for(structure, setNewProcess, "setNewProcess");
   structure->migrate(new_element, new_process);
 
-  auto checkMigrate = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkMigrate = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask && e == comm_rank){
       printf("Structure failed to migrate ranks at Ptcl: %d, Elm: %d\n", p, e);
       failures(0) = 1;

--- a/particle_structs/test/test_constructor.cpp
+++ b/particle_structs/test/test_constructor.cpp
@@ -37,7 +37,7 @@ int testParticleExistence(const char* name, PS* structure, lid_t num_ptcls) {
 
   int fails = 0;
   kkLidView count("count", 1);
-  auto checkExistence = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkExistence = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask)
       Kokkos::atomic_increment<lid_t>(&(count(0)));
   };
@@ -61,7 +61,7 @@ int setValues(const char* name, PS* structure) {
   auto bools = structure->get<2>();
   auto nums = structure->get<3>();
   int local_rank = comm_rank;
-  auto setValues = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setValues = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       dbls(p, 0) = p * e * 100.0;
       dbls(p, 1) = M_PI * p + M_PI / 2.0;
@@ -105,7 +105,7 @@ int pseudoPush(const char* name, PS* structure) {
   auto bools = structure->get<2>();
   auto nums = structure->get<3>();
   int local_rank = comm_rank;
-  auto quickMaths = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto quickMaths = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     //printf("e: %d\tp: %d\tmask: %d\n", e, p, mask);
     if (mask) {
       const double p_fp = (double) p;

--- a/particle_structs/test/test_migrate.cpp
+++ b/particle_structs/test/test_migrate.cpp
@@ -16,7 +16,7 @@ int migrateSendRight(const char* name, PS* structure) {
   int local_rank = comm_rank;
   int local_csize = comm_size;
   int num_elems = structure->nElems();
-  auto sendRight = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto sendRight = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       new_element(p) = e;
       if (e == num_elems - 1)
@@ -35,7 +35,7 @@ int migrateSendRight(const char* name, PS* structure) {
 
   pids = structure->get<0>();
   rnks = structure->get<3>();
-  auto checkPostMigrate = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkPostMigrate = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       const int pid = pids(p);
       const int rank = rnks(p);
@@ -65,7 +65,7 @@ int migrateSendRight(const char* name, PS* structure) {
 
   new_element = kkLidView("new_element", structure->capacity());
   new_process = kkLidView("new_process", structure->capacity());
-  auto sendBack = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto sendBack = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       new_element(p) = e;
       new_process(p) = rnks(p);
@@ -77,7 +77,7 @@ int migrateSendRight(const char* name, PS* structure) {
   failures = kkLidView("fails", 1);
   pids = structure->get<0>();
   rnks = structure->get<3>();
-  auto checkPostBackMigrate = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkPostBackMigrate = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       if (rnks(p) != local_rank) {
         printf("[ERROR] Test %s: Particle %d from rank %d was not sent back on rank %d\n",
@@ -109,7 +109,7 @@ int migrateSendToOne(const char* name, PS* structure) {
   auto double_slice = structure->get<1>();
   kkLidView ptcls_set("ptcls_set", 1);
   auto comm_rank_local = comm_rank;
-  auto setValues = PS_LAMBDA(const lid_t& elem_id, const lid_t& ptcl_id, const bool& mask) {
+  auto setValues = PS_LAMBDA(const lid_t& elem_id, const lid_t& ptcl_id, const lid_t& mask) {
     int_slice(ptcl_id) = comm_rank_local;
     double_slice(ptcl_id,0) = comm_rank_local * 5;
     if (Kokkos::atomic_fetch_add(&ptcls_set(0), mask) < np*5/100)
@@ -143,7 +143,7 @@ int migrateSendToOne(const char* name, PS* structure) {
 
   int_slice = structure->get<0>();
   double_slice = structure->get<1>();
-  auto checkValues = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, const bool& mask) {
+  auto checkValues = PS_LAMBDA(const lid_t& elm_id, const lid_t& ptcl_id, const lid_t& mask) {
     if (mask) {
       int rank = int_slice(ptcl_id);
       double val = double_slice(ptcl_id, 0);
@@ -176,7 +176,7 @@ int migrateToEmptyAndRefill(const char* name, PS* structure) {
   auto elem = structure->get<2>();
   int num_elems = structure->nElems();
 
-  auto sendToOdd = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto sendToOdd = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     rnks(p) = local_rank;
     elem(p) = e;
     if (mask) {
@@ -202,7 +202,7 @@ int migrateToEmptyAndRefill(const char* name, PS* structure) {
       ++fails;
       fprintf(stderr, "[ERROR] Particles remain on rank %d\n", comm_rank);
     }
-    auto checkPtcls = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+    auto checkPtcls = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
       if (mask) {
         failures(0) = 1;
         printf("[ERROR] Particle %d remains on rank %d\n", p, local_rank);
@@ -217,7 +217,7 @@ int migrateToEmptyAndRefill(const char* name, PS* structure) {
     }
     const int prev_rank = ((comm_rank - 1) + comm_size) % comm_size;
     auto new_rnks = structure->get<3>();
-    auto checkPtcls = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+    auto checkPtcls = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
       if (mask) {
         if (new_rnks(p) != local_rank && new_rnks(p) !=  prev_rank) {
           failures(0) = 1;
@@ -232,7 +232,7 @@ int migrateToEmptyAndRefill(const char* name, PS* structure) {
   rnks = structure->get<3>();
   new_element = kkLidView("new_element", structure->capacity());
   new_process = kkLidView("new_process", structure->capacity());
-  auto sendToOrig = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto sendToOrig = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     new_element(p) = e;
     if (mask) {
       new_process(p) = rnks(p);
@@ -252,7 +252,7 @@ int migrateToEmptyAndRefill(const char* name, PS* structure) {
 
   auto elems = structure->get<2>();
   new_element = kkLidView("new_element", structure->capacity());
-  auto resetElements = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto resetElements = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       new_element(p) = elems(p);
     }

--- a/particle_structs/test/test_rebuild.cpp
+++ b/particle_structs/test/test_rebuild.cpp
@@ -10,7 +10,7 @@ int rebuildNoChanges(const char* name, PS* structure) {
   auto pID = structure->get<0>();
   kkLidView new_element("new_element", structure->capacity());
   kkLidView element_sums("element_sums", structure->nElems());
-  auto setSameElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setSameElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       new_element(p) = e;
       Kokkos::atomic_add(&(element_sums(e)), p);
@@ -33,7 +33,7 @@ int rebuildNoChanges(const char* name, PS* structure) {
 
   kkLidView new_element_sums("new_element_sums", structure->nElems());
   kkLidView failed = kkLidView("failed", 1);
-  auto checkSameElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkSameElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       const lid_t id = pID(p);
       const lid_t dest_elem = new_element(id);
@@ -74,7 +74,7 @@ int rebuildNewElems(const char* name, PS* structure) {
   auto pID = structure->get<0>();
   kkLidView new_element("new_element", structure->capacity());
   kkLidView element_sums("element_sums", structure->nElems());
-  auto setElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       new_element(p) = (e*3 + p) % ne; //assign to diff elems
       Kokkos::atomic_add(&(element_sums(new_element(p))), p);
@@ -97,7 +97,7 @@ int rebuildNewElems(const char* name, PS* structure) {
 
   kkLidView new_element_sums("new_element_sums", structure->nElems());
   kkLidView failed = kkLidView("failed", 1);
-  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       const lid_t id = pID(p);
       const lid_t dest_elem = new_element(id);
@@ -137,7 +137,7 @@ int rebuildNewPtcls(const char* name, PS* structure) {
 
   auto pID = structure->get<0>();
   kkLidView new_element("new_element", structure->capacity());
-  auto setElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask)
       new_element(p) = (e*3 + p + 2) % ne; //assign to diff elems
     else
@@ -171,7 +171,7 @@ int rebuildNewPtcls(const char* name, PS* structure) {
   pID = structure->get<0>();
 
   kkLidView failed = kkLidView("failed", 1);
-  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       const lid_t id = pID(p);
       if (id < cap) { //Check old particles
@@ -210,7 +210,7 @@ int rebuildPtclsDestroyed(const char* name, PS* structure) {
   kkLidView new_element("new_element", structure->capacity());
   kkLidView num_removed("num_removed", 1);
   //Remove every 7th particle, keep other particles in same element
-  auto assign_ptcl_elems = PS_LAMBDA(const int& e, const int& p, const bool& mask){
+  auto assign_ptcl_elems = PS_LAMBDA(const int& e, const int& p, const int& mask){
     if (mask) {
       new_element(p) = e;
       if (p%7 == 0) {
@@ -234,7 +234,7 @@ int rebuildPtclsDestroyed(const char* name, PS* structure) {
   pID = structure->get<0>();
 
   kkLidView failed = kkLidView("failed", 1);
-  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       const lid_t id = pID(p);
       const lid_t dest_elem = new_element(id);
@@ -268,7 +268,7 @@ int rebuildNewAndDestroyed(const char* name, PS* structure) {
   kkLidView new_element("new_element", structure->capacity());
   kkLidView num_removed("num_removed", 1);
   //Remove every 7th particle and move others to new element
-  auto assign_ptcl_elems = PS_LAMBDA(const int& e, const int& p, const bool& mask){
+  auto assign_ptcl_elems = PS_LAMBDA(const int& e, const int& p, const int& mask){
     if (mask) {
       new_element(p) = (3*e+7)%ne;
       if (p%7 == 0) {
@@ -306,7 +306,7 @@ int rebuildNewAndDestroyed(const char* name, PS* structure) {
   pID = structure->get<0>();
 
   kkLidView failed = kkLidView("failed", 1);
-  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkElement = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       const lid_t id = pID(p);
       if (id < cap) { //Check old particles

--- a/particle_structs/test/test_structure.cpp
+++ b/particle_structs/test/test_structure.cpp
@@ -281,7 +281,7 @@ int testCopy(const char* name, PS* structure) {
   double EPSILON = .00001;
   kkLidView failure("failure", 1);
   int local_rank = comm_rank;
-  auto testTypes = PS_LAMBDA(const int& eid, const int& pid, const bool& mask) {
+  auto testTypes = PS_LAMBDA(const int& eid, const int& pid, const int& mask) {
     if (mask) {
       if (ids1(pid) != ids2(pid)) {
         printf("[ERROR] Particle ids do not match for particle %d "
@@ -323,7 +323,7 @@ int testSegmentComp(const char* name, PS* structure) {
   kkLidView failures("fails", 1);
 
   auto dbls = structure->get<1>();
-  auto setComponents = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setComponents = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       auto dbl_seg = dbls.getComponents(p);
       for (int i = 0; i < 3; ++i)
@@ -333,7 +333,7 @@ int testSegmentComp(const char* name, PS* structure) {
   pumipic::parallel_for(structure, setComponents, "Set components");
 
   const double TOL = .00001;
-  auto checkComponents = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto checkComponents = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) {
       auto comps = dbls.getComponents(p);
       for (int i = 0; i < 3; ++i) {
@@ -360,7 +360,7 @@ int testPIDs(const char* name, PS* structure) {
 
   kkLidView failures("failures", 1);
   kkLidView unsortedElems("unsortedElems", structure->capacity());
-  auto setUnsortedElems = PS_LAMBDA(const lid_t& e, const lid_t& p, const bool& mask) {
+  auto setUnsortedElems = PS_LAMBDA(const lid_t& e, const lid_t& p, const lid_t& mask) {
     if (mask) unsortedElems(p) = e;
   };
   pumipic::parallel_for(structure, setUnsortedElems, "setUnsortedElems");

--- a/particle_structs/test/typeTest.cpp
+++ b/particle_structs/test/typeTest.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
     auto scs_first = scs->get<0>(); //int
     auto scs_second = scs->get<1>(); //double[2]
 
-    auto setValues = PS_LAMBDA(int element_id, int particle_id, bool mask) {
+    auto setValues = PS_LAMBDA(int element_id, int particle_id, int mask) {
       if (mask) {
         scs_first(particle_id) = element_id;
         scs_second(particle_id, 0) = 1.0;

--- a/performance_tests/ps_combo264.cpp
+++ b/performance_tests/ps_combo264.cpp
@@ -155,7 +155,7 @@ int main(int argc, char* argv[]) {
       auto nums = ptcls->get<1>();
       auto lint = ptcls->get<2>();
 
-      auto pseudoPush = PS_LAMBDA(const int& e, const int& p, const bool& mask) {
+      auto pseudoPush = PS_LAMBDA(const int& e, const int& p, const int& mask) {
         if (mask) {
           for (int i = 0; i < 17; i++) {
             dbls(p,i) = 10.3;
@@ -213,7 +213,7 @@ int main(int argc, char* argv[]) {
       Kokkos::Timer tp;
       kkLidView new_process("new_process", ptcls->capacity());
       if (comm_size > 1) {
-        auto to_new_processes = PS_LAMBDA(const int& e, const int& p, const bool& mask) {
+        auto to_new_processes = PS_LAMBDA(const int& e, const int& p, const int& mask) {
           if (mask) {
             auto generator = pool.get_state();
             double prob = generator.drand(1.0);

--- a/src/pumipic_lb.hpp
+++ b/src/pumipic_lb.hpp
@@ -142,7 +142,7 @@ private:
     Omega_h::Write<agi::wgt_t> weights(sbar_ids.size() + 1, 0);
     Omega_h::LOs elem_sbars = getSbarIDs(picparts);
     auto sbar_to_vert_local = sbar_to_vert;
-    auto accumulateWeight = PS_LAMBDA(const int elm, const int ptcl, const bool mask) {
+    auto accumulateWeight = PS_LAMBDA(const int elm, const int ptcl, const int mask) {
       if (mask) {
         const int new_rank = new_procs(ptcl);
         if (new_rank == comm_rank) {
@@ -241,7 +241,7 @@ private:
     auto sbar_to_index = plan.sbar_to_index;
     auto part_ids = plan.part_ids;
     auto owners = picparts.entOwners(picparts->dim());
-    auto selectNonCoreParticles = PS_LAMBDA(const int elm, int ptcl, const bool mask) {
+    auto selectNonCoreParticles = PS_LAMBDA(const int elm, int ptcl, const int mask) {
       const Omega_h::LO new_e = new_elems(ptcl);
       const Omega_h::LO new_p = new_parts(ptcl);
       if (mask && new_p == comm_rank && new_e != -1) {
@@ -264,7 +264,7 @@ private:
       }
     };
     parallel_for(ptcls, selectNonCoreParticles, "selectNonCoreParticles");
-    auto selectParticles = PS_LAMBDA(const int elm, const int ptcl, const bool mask) {
+    auto selectParticles = PS_LAMBDA(const int elm, const int ptcl, const int mask) {
       const Omega_h::LO new_e = new_elems(ptcl);
       const Omega_h::LO new_p = new_parts(ptcl);
       if (mask && new_p == comm_rank && new_e != -1) {

--- a/src/pumipic_ptcl_ops.hpp
+++ b/src/pumipic_ptcl_ops.hpp
@@ -35,7 +35,7 @@ namespace pumipic {
     auto owners = mesh.entOwners(mesh->dim());
     auto safe = mesh.safeTag();
     int comm_rank = mesh.comm()->rank();
-    auto setUnsafePtcls = PS_LAMBDA(const int elm, const int ptcl, const bool mask) {
+    auto setUnsafePtcls = PS_LAMBDA(const int elm, const int ptcl, const int mask) {
       new_procs[ptcl] = comm_rank;
       const int nelm = elems[ptcl];
       new_elems[ptcl] = nelm;

--- a/test/pseudoPushAndSearch.cpp
+++ b/test/pseudoPushAndSearch.cpp
@@ -219,7 +219,7 @@ OMEGA_H_DEVICE o::Matrix<3, 4> gatherVectors(o::Reals const& a, o::Few<o::LO, 4>
 
 void setPtclIds(PS* ptcls) {
   auto pid_d = ptcls->get<2>();
-  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const bool& mask) {
+  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const int& mask) {
     pid_d(pid) = pid;
   };
   ps::parallel_for(ptcls, setIDs);

--- a/test/pseudoXGCm.cpp
+++ b/test/pseudoXGCm.cpp
@@ -158,7 +158,7 @@ void search(p::Mesh& picparts, PS* ptcls, p::Distributor<>& dist, bool output) {
 
 void setPtclIds(PS* ptcls) {
   auto pid_d = ptcls->get<2>();
-  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const bool& mask) {
+  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const int& mask) {
     pid_d(pid) = pid;
   };
   ps::parallel_for(ptcls, setIDs);

--- a/test/pseudoXGCm_scatter.cpp
+++ b/test/pseudoXGCm_scatter.cpp
@@ -10,7 +10,7 @@ typedef Kokkos::DefaultExecutionSpace ExeSpace;
 
 void setPtclIds(PS* ptcls) {
   auto pid_d = ptcls->get<2>();
-  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const bool& mask) {
+  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const int& mask) {
     pid_d(pid) = pid;
   };
   ps::parallel_for(ptcls, setIDs);

--- a/test/search2d.cpp
+++ b/test/search2d.cpp
@@ -25,7 +25,7 @@ typedef ps::ParticleStructure<Particle> PS;
 
 void setPtclIds(PS* ptcls) {
   auto pid_d = ptcls->get<2>();
-  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const bool& mask) {
+  auto setIDs = PS_LAMBDA(const int& eid, const int& pid, const int& mask) {
     if(mask)
       pid_d(pid) = pid;
   };

--- a/test/test_adj.cpp
+++ b/test/test_adj.cpp
@@ -551,7 +551,7 @@ void push_ptcls(PS* ptcls, o::Real distance) {
   auto cur = ptcls->get<0>();
   auto tgt = ptcls->get<1>();
   auto angle = ptcls->get<3>();
-  auto push = PS_LAMBDA(const p::lid_t elm, const p::lid_t ptcl, const bool mask) {
+  auto push = PS_LAMBDA(const p::lid_t elm, const p::lid_t ptcl, const p::lid_t mask) {
     if (mask) {
       for (int i = 0; i < 3; ++i) {
         tgt(ptcl, i) = tgt(ptcl,i) + distance * angle(ptcl, i);
@@ -569,7 +569,7 @@ bool test_parent_elements(o::Mesh mesh, PS* ptcls, o::Write<o::LO> elem_ids, con
   auto pids = ptcls->get<2>();
   o::Reals elmArea = measure_elements_real(&mesh);
   o::Write<o::LO> ptcl_done(ptcls->capacity(), 0, "ptcl_done");
-  auto setDone = PS_LAMBDA(const o::LO, const o::LO ptcl, const bool mask) {
+  auto setDone = PS_LAMBDA(const o::LO, const o::LO ptcl, const o::LO mask) {
     ptcl_done[ptcl] = (!mask | (elem_ids[ptcl] == -1));
   };
   p::parallel_for(ptcls, setDone, "setDone");
@@ -593,7 +593,7 @@ bool check_inside_bbox(o::Mesh mesh, PS* ptcls, o::Write<o::LO> xFaces, const o:
   auto box = o::get_bounding_box<DIM>(&mesh);
   auto x_ps_tgt = ptcls->get<1>();
   o::Write<o::LO> failures(1,0);
-  auto checkInteriors = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const bool mask) {
+  auto checkInteriors = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const o::LO mask) {
     const o::LO face = xFaces[ptcl];
     const o::Vector<3> ptcl_pos = makeVector3(ptcl, x_ps_tgt);
     if (mask && face == -1) {
@@ -632,7 +632,7 @@ bool check_intersections_3d(o::Mesh mesh, PS* ptcls, o::Write<o::LO> elem_ids,
   o::Write<o::LO> failures(1,0);
   const auto face_verts =  mesh.ask_verts_of(2);
   const auto coords = mesh.coords();
-  auto checkIntersections3d = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const bool mask) {
+  auto checkIntersections3d = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const o::LO mask) {
     const o::LO face = intersection_faces[ptcl];
     if (mask && face != -1) {
       //check intersection point is in the intersection face
@@ -661,7 +661,7 @@ bool check_intersections_2d(o::Mesh mesh, PS* ptcls, o::Write<o::LO> intersectio
   o::Write<o::LO> failures(1,0);
   const auto edge_verts =  mesh.ask_verts_of(1);
   const auto coords = mesh.coords();
-  auto checkIntersections2d = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const bool mask) {
+  auto checkIntersections2d = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const o::LO mask) {
     const o::LO edge = intersection_faces[ptcl];
     if (mask && edge != -1) {
       //check intersection point is in the intersection face
@@ -701,7 +701,7 @@ bool test_wall_intersections(o::Mesh mesh, PS* ptcls, o::Write<o::LO> elem_ids, 
   //Test intersection points against motion and intersection face on parent element
   auto x_ps_orig = ptcls->get<0>();
   auto x_ps_tgt = ptcls->get<1>();
-  auto checkIntersections = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const bool mask) {
+  auto checkIntersections = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const o::LO mask) {
     const o::LO face = intersection_faces[ptcl];
     const o::LO searchElm = elem_ids[ptcl];
     if (mask && face != -1) {
@@ -802,7 +802,7 @@ void reflect_intersections(PS* ptcls, o::Write<o::LO> xFaces, o::Write<o::Real> 
   auto tgt = ptcls->get<1>();
   auto dir = ptcls->get<3>();
   int dim = xPoints.size() / ptcls->capacity();
-  auto reflectParticles = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const bool mask) {
+  auto reflectParticles = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const o::LO mask) {
     o::LO face = xFaces[ptcl];
     if (mask && face != -1) {
       for (int i = 0; i < dim; ++i) {
@@ -815,7 +815,7 @@ void reflect_intersections(PS* ptcls, o::Write<o::LO> xFaces, o::Write<o::Real> 
 }
 
 void delete_intersections(PS* ptcls, o::Write<o::LO> elem_ids, o::Write<o::LO> xFaces) {
-  auto deleteIntersections = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const bool mask) {
+  auto deleteIntersections = PS_LAMBDA(const o::LO elm, const o::LO ptcl, const o::LO mask) {
     o::LO face = xFaces[ptcl];
     if (mask && face != -1) {
       elem_ids[ptcl] = -1;

--- a/test/test_lb.cpp
+++ b/test/test_lb.cpp
@@ -186,7 +186,7 @@ void balancePtcls(pumipic::Mesh& picparts, PS* ptcls, pumipic::ParticleBalancer&
   auto is_safe = picparts.safeTag();
   auto owners = picparts.entOwners(picparts.dim());
   auto vals = ptcls->get<0>();
-  auto setValues = PS_LAMBDA(const int elm, const int ptcl, const bool mask) {
+  auto setValues = PS_LAMBDA(const int elm, const int ptcl, const int mask) {
     if (mask) {
       vals(ptcl) = comm_rank;
       const auto safe = is_safe[elm];


### PR DESCRIPTION
Fix part of issue #156 and #119 . As reported, the boolean mask implementation became corrupted when used with a large number of particles. Switching to an integer mask resolves this issue.