### PR TITLE
Fix ParticleBalancer sbar-map index for contiguous receives

### DIFF
--- a/src/pumipic_lb.cpp
+++ b/src/pumipic_lb.cpp
@@ -95,7 +95,7 @@ namespace pumipic {
       Parts parts;
       parts.insert(comm_rank);
       for (int j = 0; j < nbuffers; ++j) {
-        int index = j * nbuffers + i;
+        int index = j * nelms + i;
         if (safe_core_per_buffer[index])
           parts.insert(buffer_ranks[j]);
       }


### PR DESCRIPTION
## Summary

`yus/debug_mpi_polaris` (commit [`8d6acb3`](https://github.com/SCOREC/pumi-pic/commit/8d6acb38260c134e8505f7148fe5d8eb4e8a057a)) replaces the strided `MPI_Type_vector` receive in the ParticleBalancer safe-zone exchange with contiguous per-buffer receives, which resolves the Cray MPICH "Recv Pack Buffer alloc" failure of #159. The same commit updated the index expression in `buildLocalSbarMap` for the new layout, but the new expression multiplies the buffer-rank index by `nbuffers` where the distance between buffer blocks is `nelms`, so the sbar map it builds no longer matches the one the `MPI_Type_vector` implementation produces. This PR is the one-line index correction.

## The issue

In [`ParticleBalancer::ParticleBalancer`, `src/pumipic_lb.cpp` lines 46-49](https://github.com/SCOREC/pumi-pic/blob/8d6acb38260c134e8505f7148fe5d8eb4e8a057a/src/pumipic_lb.cpp#L46-L49), each `MPI_Irecv` writes one block of `core_nents` entries into `safe_core_per_buffer`: the block for buffer rank `buffer_ranks[i]` starts at `i * core_nents`, with `i` the loop index over the `nbuffers` buffer ranks. [`buildLocalSbarMap` (lines 89-104)](https://github.com/SCOREC/pumi-pic/blob/8d6acb38260c134e8505f7148fe5d8eb4e8a057a/src/pumipic_lb.cpp#L89-L104) is called with `core_nents` as its `nelms` argument ([lines 63-65](https://github.com/SCOREC/pumi-pic/blob/8d6acb38260c134e8505f7148fe5d8eb4e8a057a/src/pumipic_lb.cpp#L63-L65)); inside it, `i` runs over the `nelms` core elements and `j` over the `nbuffers` buffer ranks, so the safe flag of element `i` with respect to buffer rank `j` sits at `j * nelms + i`. [Line 98](https://github.com/SCOREC/pumi-pic/blob/8d6acb38260c134e8505f7148fe5d8eb4e8a057a/src/pumipic_lb.cpp#L98) instead computes

```cpp
int index = j * nbuffers + i;
```

For any buffer index `j > 0` the two expressions agree only when `nbuffers == nelms`; the single-buffer case is degenerate because both reduce to `i`. In multi-buffer shapes with `nbuffers != nelms` the lookup reads the wrong `safe_core_per_buffer` entry, safe-zone flags get attributed to the wrong element/buffer-rank pair, and the resulting sbar sets differ from those the pre-8d6acb3 strided code builds from the same exchange.

The wrong read produces no error message: for the typical shapes (`nelms > nbuffers`) every access stays inside the allocation, so the run continues with a silently wrong sbar map; when `nbuffers` exceeds `nelms` the expression can even index past the end of `safe_core_per_buffer`.

## Testing

The updated expression was checked against the master implementation directly: filling `safe_core_per_buffer` with a unique tag per (element, buffer rank) cell and comparing what each index expression reads, the updated index reproduces the strided reference exactly (0 mismatches on every tested shape, including the 592923-element count visible in the #159 stack trace), while the 8d6acb3 expression does not. The standalone check is available [here](https://github.com/electronuclear/pumi-pic/blob/c532146f6304af024813f7f0dda43dcf067f01b6/test/sbar_index_check.cpp).

On Polaris (A100 nodes, Cray MPICH), with this correction on top of 8d6acb3, the "Recv Pack Buffer alloc" failure we reproduced at 29.26M mesh elements / 40 ranks is gone, and the Comet DSMC code (the application in #159) loading an 84M-element partitioned mesh through `pumipic::read` ran a 9000-step test to completion with no particle loss:

```text
time step = 9000; particles = 87236458, 87.2365 million; ...
9000 number of time steps, total time 2524.901469
[...]
simulation finished
```

## References

- #159, the crash this branch addresses; the defect was found while running the partitioned-mesh loading path of #134 at scale.
- Commit [`8d6acb3`](https://github.com/SCOREC/pumi-pic/commit/8d6acb38260c134e8505f7148fe5d8eb4e8a057a) ("remove usage of MPI_Type_Vector"), which this PR corrects.

This PR targets `yus/debug_mpi_polaris` because the contiguous receive exists only there; happy to retarget if the fix should be routed differently.
