### PR TITLE
include Omega_h_adapt.hpp in pumipic_adaptation.hpp

### DIFF
--- a/src/pumipic_adaptation.hpp
+++ b/src/pumipic_adaptation.hpp
@@ -6,6 +6,7 @@
 #include "Omega_h_scalar.hpp"
 #include "Omega_h_element.hpp"
 #include "Omega_h_shape.hpp"
+#include "Omega_h_adapt.hpp"
 #include "pumipic_utils.hpp"
 #include <MemberTypeLibraries.h>
 


### PR DESCRIPTION
`ParticleAdapt` derives from `UserTransfer` and holds an `AdaptOpts*`, and
Omega_h declares both in `Omega_h_adapt.hpp`, which the header does not include:

https://github.com/SCOREC/pumi-pic/blob/a3a56076fd0098c707d10409adfc48d3e02be210/src/pumipic_adaptation.hpp#L35-L39

The missing-declaration errors are masked in this branch because
`test/particle_adapt.cpp` includes `Omega_h_adapt.hpp` first. A file that includes
the installed header on its own does not compile:

    pumipic_adaptation.hpp(35): error: not a class or struct name
    pumipic_adaptation.hpp(39): error: identifier "AdaptOpts" is undefined

This adds the include with the other Omega_h ones.
