### PR TITLE
Fix reduceCommArray boundary offsets to index by source rank

### DIFF
--- a/src/pumipic_comm.cpp
+++ b/src/pumipic_comm.cpp
@@ -332,9 +332,12 @@ namespace pumipic {
           }
         }
         else {
-          const int size = offset_bounded_per_dim[edim][finished_neighbor+1] -
-            offset_bounded_per_dim[edim][finished_neighbor];
-          const int start = offset_bounded_per_dim[edim][finished_neighbor];
+          //The bounded offsets are indexed by the rank the message came from,
+          //which is not the index MPI_Waitany returns.
+          const int src_rank = status.MPI_SOURCE;
+          const int size = offset_bounded_per_dim[edim][src_rank+1] -
+            offset_bounded_per_dim[edim][src_rank];
+          const int start = offset_bounded_per_dim[edim][src_rank];
           if (op == SUM_OP) {
             auto reduce_op = OMEGA_H_LAMBDA(Omega_h::LO i) {
               int index = bounded_ent_ids_local[start+i];

--- a/test/test_comm_array.cpp
+++ b/test/test_comm_array.cpp
@@ -14,9 +14,9 @@ int main(int argc, char** argv) {
   pumipic::Library pic_lib(&argc, &argv);
   Omega_h::Library& lib = pic_lib.omega_h_lib();
   int rank = lib.world()->rank();;
-  if (argc != 3) {
+  if (argc != 3 && argc != 4) {
     if (!rank)
-      fprintf(stderr, "Usage: %s <mesh> <partition filename>\n", argv[0]);
+      fprintf(stderr, "Usage: %s <mesh> <partition filename> [buffer_layers]\n", argv[0]);
     MPI_Finalize();
     return EXIT_FAILURE;
   }
@@ -45,26 +45,38 @@ int main(int argc, char** argv) {
   //Owner of each element
   Omega_h::Write<Omega_h::LO> owner(host_owners);
 
+  //REPRO: buffer depth under test (upstream default is 1) and a real exit code
+  const int buffer_layers = (argc == 4) ? atoi(argv[3]) : 1;
+  int failures = 0;
+  if (!rank)
+    printf("REPRO buffer_layers=%d\n", buffer_layers);
+
   for (int i = 0; i <= mesh.dim(); ++i) {
-    if (!fullBufferTest(mesh, owner, i))
+    if (!fullBufferTest(mesh, owner, i)) {
       printf("fullBufferTest on dimension %d failed on rank %d\n", i, rank);
+      ++failures;
+    }
   }
   MPI_Barrier(MPI_COMM_WORLD);
 
   
   //********* Construct the PIC parts *********//
-  pumipic::Mesh picparts(mesh, owner, 1, 0);
+  pumipic::Mesh picparts(mesh, owner, buffer_layers, 0);
 
   for (int i = 0; i <= picparts.dim(); ++i) {
-    if (!minOwnership(picparts, i))
+    if (!minOwnership(picparts, i)) {
       printf("minOwnership on dimension %d failed on rank %d\n", i, rank);
+      ++failures;
+    }
   }
 
   MPI_Barrier(MPI_COMM_WORLD);
 
   for (int i = 0; i <= 0/*picparts.dim()*/; ++i) {
-    if (!sumEntities(picparts, i))
+    if (!sumEntities(picparts, i)) {
       printf("sumEntities on dimension %d failed on rank %d\n", i, rank);
+      ++failures;
+    }
   }
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -86,6 +98,7 @@ int main(int argc, char** argv) {
   Omega_h::HostWrite<Omega_h::LO> fail_host(fail);
   if (fail_host[0]) {
     fprintf(stderr, "Max reduce failed on %d\n", rank);
+    ++failures;
   }
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -112,9 +125,11 @@ int main(int argc, char** argv) {
   
   if (!success) {
     fprintf(stderr, "Multielement comm operation failed on %d\n", lib.world()->rank());
+    ++failures;
   }
 
-  return 0;
+  printf("REPRO rank %d failures=%d\n", rank, failures);
+  return failures != 0;
 }
 
 bool minOwnership(pumipic::Mesh& picparts, int dim) {

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -46,6 +46,12 @@ mpi_test(comm_array_pisces 4
 mpi_test(comm_array_2d_box 4
   ./comm_array ${TEST_DATA_DIR}/2d_box/2d_box.msh testing_2d_box_4.ptn)
 
+mpi_test(comm_array_pisces_0layers 4
+  ./comm_array ${TEST_DATA_DIR}/pisces/gitr.msh testing_pisces_4.ptn 0)
+
+mpi_test(comm_array_2d_box_0layers 4
+  ./comm_array ${TEST_DATA_DIR}/2d_box/2d_box.msh testing_2d_box_4.ptn 0)
+
 mpi_test(file_rw_cube_4 4
   ./file_rw
   ${TEST_DATA_DIR}/cube.msh


### PR DESCRIPTION
## Summary

`Mesh::reduceCommArray` waits for its boundary messages one at a time with
`MPI_Waitany`, which reports the index of the request that finished. The branch
that accumulates a bounding part's contribution uses that index to look up
`offset_bounded_per_dim`, which is indexed by the rank the message came from. The
position and the rank agree only when a part's place in the request array happens
to equal its rank; where they differ, the contribution is read with another rank's
length and written at another rank's offset, so boundary values are accumulated
onto the wrong entities. This PR takes the rank from the completion status
instead.

The reductions at risk are `SUM_OP`, `MAX_OP` and `MIN_OP` on entity dimensions
below the mesh dimension. `BCAST_OP` is unaffected because the fan-in is skipped
for it, and the element dimension is unaffected because `setupComm` returns before
it records any bounding-part information when `edim == dim()`.

## The issue

The offsets are built per rank in `setupComm`: `recv_boundary_offset_host` is
sized `comm_size + 1` and filled by a loop over ranks, then stored as
`offset_bounded_per_dim[edim]`:

https://github.com/SCOREC/pumi-pic/blob/c09ad0456221a5e93a383c917557c1a6a503f6e2/src/pumipic_comm.cpp#L129-L132

`MPI_Irecv` is then called for each bounding part with that same rank index:

https://github.com/SCOREC/pumi-pic/blob/c09ad0456221a5e93a383c917557c1a6a503f6e2/src/pumipic_comm.cpp#L295-L298

`finished_neighbor`, however, is a position in `recv_requests`, whose earlier
entries belong to the fully buffered parts and whose later entries follow the
order of `boundary_parts`:

https://github.com/SCOREC/pumi-pic/blob/c09ad0456221a5e93a383c917557c1a6a503f6e2/src/pumipic_comm.cpp#L303-L306

and `finished_neighbor` is used as a rank here:

https://github.com/SCOREC/pumi-pic/blob/c09ad0456221a5e93a383c917557c1a6a503f6e2/src/pumipic_comm.cpp#L335-L337

The fan-out back to the same parts indexes the array by rank, as intended:

https://github.com/SCOREC/pumi-pic/blob/c09ad0456221a5e93a383c917557c1a6a503f6e2/src/pumipic_comm.cpp#L416-L418

Nothing announces the mistake. Every access stayed inside the allocation in the
configurations we ran, so the reduction simply returns wrong values.

## Testing

`test/test_comm_array.cpp` fixes the buffer depth at one layer and returns zero
whatever its checks report. This PR extends it to take the depth as an optional
third argument, print a per-rank count of failed checks, and return a non-zero
code when any check fails. It also registers the two zero-layer configurations
in `test/testing.cmake`.

Built on two trees that differ only by the change, both carrying the test
changes:

| configuration | as it stands | with the change |
|---|---|---|
| `2d_box`, 4 ranks, 1 buffer layer (`comm_array_2d_box`) | passes | passes |
| `2d_box`, 4 ranks, 0 buffer layers | `sumEntities` fails on all 4 ranks | passes |
| `pisces`, 4 ranks, 0 buffer layers | `sumEntities` fails on all 4 ranks | passes |
| `2d_box`, 8 ranks, 1 buffer layer | `sumEntities` fails on 6 of 8 ranks | passes |

Printing the request index and the source rank side by side inside the branch: at
8 ranks and one buffer layer, 32 of the 36 boundary messages arrive with a request
index that differs from the source rank; at 4 ranks and zero buffer layers, all 19
do.

The two configurations registered before this change never reach this code path:
with four parts on these meshes every part is buffered whole, so none is only
partially buffered, and an instrumented build enters the path zero times in both.

The full test suite passes on the patched tree, 61 of 61, including the two
entries this change adds.
